### PR TITLE
[FIX] Windows-compatible download-files & local file fetch

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaimprotocol/zk-symmetric-crypto",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "JS Wrappers for Various ZK Snark Circuits",
   "type": "module",
   "exports": {

--- a/js/src/file-fetch.ts
+++ b/js/src/file-fetch.ts
@@ -78,7 +78,10 @@ export function makeLocalFileFetch(
 			// a browser env
 			const { readFile } = await import('fs/promises')
 			const { join, dirname } = await import('path')
-			const __dirname = dirname(import.meta.url.replace('file://', ''))
+			const { fileURLToPath } = await import('url')
+			// fileURLToPath handles the Windows file:///F:/... -> F:\... conversion;
+			// stripping the `file://` prefix by hand leaves a leading slash that breaks fs ops.
+			const __dirname = dirname(fileURLToPath(import.meta.url))
 			const fullPath = join(__dirname, path)
 			const buff = await readFile(fullPath)
 			return buff

--- a/js/src/scripts/download-files.ts
+++ b/js/src/scripts/download-files.ts
@@ -1,21 +1,22 @@
-import { exec } from 'child_process'
+import { spawn } from 'child_process'
 import { createWriteStream } from 'fs'
 import { mkdir, rename, rm } from 'fs/promises'
 import { dirname, join } from 'path'
 import { Readable } from 'stream'
 import { pipeline } from 'stream/promises'
-import { promisify } from 'util'
+import { fileURLToPath } from 'url'
 import { GIT_COMMIT_HASH } from '../config.ts'
 import type { Logger } from '../types.ts'
 
-const execPromise = promisify(exec)
 const logger: Logger = console
 
 const ZIP_URL = `https://github.com/reclaimprotocol/zk-symmetric-crypto/archive/${GIT_COMMIT_HASH}.zip`
 const DOWNLOAD_DIR = './zk-symmetric-crypto-download'
 const EXTRACTED_DIR = `./zk-symmetric-crypto-${GIT_COMMIT_HASH}`
 
-const __dirname = dirname(import.meta.url.replace('file://', ''))
+// fileURLToPath handles the Windows file:///F:/... -> F:\... conversion;
+// stripping the `file://` prefix by hand leaves a leading slash that breaks fs ops.
+const __dirname = dirname(fileURLToPath(import.meta.url))
 const BASE_DIR = join(__dirname, '../../')
 const DIRS_TO_COPY = [
 	'resources',
@@ -49,10 +50,34 @@ async function downloadAndExtractZip() {
 
 	logger.info('downloaded ZIP, extracting...')
 
-	// Extract ZIP using unzip command
-	await execPromise(`unzip -q ${zipPath} -d ./`)
+	await extractZip(zipPath, './')
 
 	logger.info(`extracted to ${EXTRACTED_DIR}`)
+}
+
+async function extractZip(zipFile: string, destDir: string) {
+	// Windows ships PowerShell but not `unzip`; everywhere else, `unzip` is the
+	// safe assumption. Using spawn (not exec) so paths with spaces stay intact.
+	if(process.platform === 'win32') {
+		await runCmd('powershell', [
+			'-NoProfile',
+			'-ExecutionPolicy', 'Bypass',
+			'-Command',
+			`Expand-Archive -LiteralPath '${zipFile}' -DestinationPath '${destDir}' -Force`,
+		])
+	} else {
+		await runCmd('unzip', ['-q', zipFile, '-d', destDir])
+	}
+}
+
+function runCmd(cmd: string, args: string[]) {
+	return new Promise<void>((resolve, reject) => {
+		const child = spawn(cmd, args, { stdio: 'inherit' })
+		child.on('error', reject)
+		child.on('exit', code => (
+			code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))
+		))
+	})
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- `js/src/scripts/download-files.ts` and `js/src/file-fetch.ts` build `__dirname` via `dirname(import.meta.url.replace('file://', ''))`. On Windows that yields `/F:/...` (extra leading slash), which `fs` ops then resolve relative to the drive's CWD — producing paths like `F:\F:\...` that don't exist and breaking the `rename`/`readFile`. Switched to `fileURLToPath(import.meta.url)`, which converts the URL correctly on all platforms.
- The download script shelled out to `unzip` via `exec`. Windows doesn't ship with `unzip` by default. Added an `extractZip` helper that uses PowerShell's `Expand-Archive` on `win32` and `unzip` elsewhere, via `spawn` so paths with spaces survive shell tokenization.
- No behavior change on Linux/macOS — same tool, same flags.
- `gnark/utils.ts` has the same `file://` strip pattern but is intentionally left alone since gnark binaries are Linux-only per the readme, so that path never runs on Windows.

## Test plan
- [ ] On Windows: `npm i` then `node node_modules/@reclaimprotocol/zk-symmetric-crypto/lib/scripts/download-files` completes and populates `resources/` and `bin/` under the installed package
- [ ] On Windows: after running the download script, `makeLocalFileFetch()` resolves a circuit file (e.g. `snarkjs/chacha20/circuit.wasm`) successfully
- [ ] On Linux: same script run still works end-to-end (regression check — `unzip` path unchanged in flags)
- [ ] `npx tsc -p tsconfig.build.json --noEmit` passes (verified locally)